### PR TITLE
docs: Remove license section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,6 @@ A sophisticated quote management application that serves as a home for worldwide
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
-## 📄 License
-
-This project is licensed under the MIT License - see the LICENSE file for details.
-
 ## 👨‍💻 Author
 
 **Sandeep Saini**


### PR DESCRIPTION
This PR removes the license section from the README file as we don't have a license for this project yet.

### Changes Made
- Removed license section from README.md
- All other documentation sections remain unchanged

### Testing
- [x] Verified README formatting
- [x] Confirmed all links are working
- [x] No other content affected

Please review the changes.