### PR TITLE
feat: Add Material 3 theme and enhance quote management

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,7 +30,7 @@
               "src/manifest.webmanifest"
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/indigo-pink.css",
+              "src/theme.scss",
               "node_modules/bootstrap/dist/css/bootstrap.min.css",
               "node_modules/ngx-spinner/animations/square-jelly-box.css",
               "src/styles.scss"

--- a/src/app/components/confirm-dialog/confirm-dialog.component.ts
+++ b/src/app/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,29 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  standalone: true,
+  imports: [MatDialogModule, MatButtonModule],
+  template: `
+    <h2 mat-dialog-title>Confirm Action</h2>
+    <mat-dialog-content>
+      <p>{{ data.message }}</p>
+    </mat-dialog-content>
+    <mat-dialog-actions align="center">
+      <button mat-button (click)="onNoClick()">Cancel</button>
+      <button mat-flat-button color="warn" [mat-dialog-close]="true">Unsave</button>
+    </mat-dialog-actions>
+  `
+})
+export class ConfirmDialogComponent {
+  constructor(
+    public dialogRef: MatDialogRef<ConfirmDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { message: string }
+  ) {}
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/components/quote-card/quote-card.component.html
+++ b/src/app/components/quote-card/quote-card.component.html
@@ -15,7 +15,7 @@
                         content_copy
                     </mat-icon>
                 </button>
-                <button mat-icon-button class="text-light" (click)="saveToLocalStorage(quoteData())"
+                <button mat-icon-button class="text-light" (click)="toggleSave(quoteData())"
                     [matTooltip]="isQuoteSaved(quoteData()) ? 'Bookmarked' : 'Bookmark'">
                     <mat-icon>
                         {{ isQuoteSaved(quoteData()) ? 'bookmark' : 'bookmark_border' }}

--- a/src/app/components/saved-quotes/saved-quotes.component.html
+++ b/src/app/components/saved-quotes/saved-quotes.component.html
@@ -1,17 +1,19 @@
 <div class="container p-4">
     <h4 class="display-4 text-center mb-5">Saved quotes</h4>
-    @for (quote of quotesList(); track $index) {
-    <div class="col-md-6 mb-4">
-        <app-quote-card [quoteData]="quote"></app-quote-card>
-    </div>
-    } @empty {
-    <div class="text-center mt-5">
-        <!-- <div class="mb-3">
-            <mat-icon>sentiment_very_satisfied</mat-icon>
-        </div> -->
-        <div class="mb-3 fs-4">Oops! No quotes in your nest yet.<br>Go catch some wisdom and save your favorites!
+    <div class="row">
+        @for (quote of sharedService.savedQuotes(); track quote.id) {
+        <div class="col-md-6 mb-4">
+            <app-quote-card [quoteData]="quote"></app-quote-card>
         </div>
-        <button class="rounded-5 px-4" mat-stroked-button (click)="goToQuotes()">Let's Fill This Nest!</button>
+        } @empty {
+        <div class="text-center mt-5">
+            <!-- <div class="mb-3">
+                <mat-icon>sentiment_very_satisfied</mat-icon>
+            </div> -->
+            <div class="mb-3 fs-4">Oops! No quotes in your nest yet.<br>Go catch some wisdom and save your favorites!
+            </div>
+            <button class="rounded-5 px-4" mat-stroked-button (click)="goToQuotes()">Let's Fill This Nest!</button>
+        </div>
+        }
     </div>
-    }
 </div>

--- a/src/app/components/saved-quotes/saved-quotes.component.ts
+++ b/src/app/components/saved-quotes/saved-quotes.component.ts
@@ -1,9 +1,10 @@
-import { Component, signal, WritableSignal } from '@angular/core';
+import { Component, Signal } from '@angular/core';
 import { QuoteCardComponent } from '../quote-card/quote-card.component';
 import { QuoteSlateInterface } from 'src/app/interfaces/quote-slate.interface';
 import { Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { SharedService } from '../../services/shared.service';
 
 @Component({
   selector: 'app-saved-quotes',
@@ -13,30 +14,14 @@ import { MatIconModule } from '@angular/material/icon';
   imports: [QuoteCardComponent, MatButtonModule, MatIconModule],
 })
 export class SavedQuotesComponent {
-  quotesList: WritableSignal<QuoteSlateInterface[]> = signal([]);
+  constructor(
+    private router: Router,
+    public sharedService: SharedService
+  ) {}
   
-  constructor(private router: Router) { }
-  
-  ngOnInit() {
-    this.getSavedQuotes();
-  }
-
-  getSavedQuotes() {
-    try {
-      const data = localStorage.getItem('savedQuotes');
-      this.quotesList.set(JSON.parse(data || '[]') as QuoteSlateInterface[]);
-    } catch (e) { }
-  }
-
-  unsaveQuote(quote: QuoteSlateInterface) {
-    const data = localStorage.getItem('savedQuotes');
-    let savedQuotes: QuoteSlateInterface[] = JSON.parse(data || '[]');
-    savedQuotes = savedQuotes.filter(q => q.id !== quote.id);
-    localStorage.setItem('savedQuotes', JSON.stringify(savedQuotes));
-    this.getSavedQuotes();
-  }
-
   goToQuotes() {
     this.router.navigate(['/home']);
   }
 }
+
+

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -1,0 +1,30 @@
+@use '@angular/material' as mat;
+
+// Include the common styles for Angular Material
+@include mat.core();
+
+// Define a Material 3 theme
+$my-theme: mat.define-theme((
+  color: (
+    theme-type: light,
+    primary: mat.$azure-palette,
+    tertiary: mat.$blue-palette,
+  ),
+  typography: (
+    brand-family: 'Open Sans',
+    plain-family: 'Open Sans',
+  ),
+  density: (
+    scale: 0,
+  )
+));
+
+// Apply the theme to all components
+:root {
+  @include mat.all-component-themes($my-theme);
+}
+
+// Ensure Material 3 styling is applied
+html {
+  @include mat.theme($my-theme);
+}


### PR DESCRIPTION
This PR adds Material 3 theme support and enhances quote management with confirmation dialogs and centralized state management.

## Overview
Comprehensive update introducing Material Design 3 styling and improved quote management workflow with better UX.

## Changes Included

### Material 3 Theme System
- Created `theme.scss` with Material 3 design system configuration
- Implemented custom color palette using Azure (primary) and Blue (tertiary)
- Configured typography using 'Open Sans' font family
- Applied Material 3 theme globally to all components

### Quote Management Enhancements
- **New ConfirmDialogComponent**: Standalone component for confirmation dialogs
- **QuoteCardComponent**: Added toggleSave() method for smart save/unsave handling
- **SharedService Improvements**: Centralized saved quotes with WritableSignal
- **SavedQuotesComponent**: Simplified to use centralized service state

### Testing Status
- [x] Material 3 theme applies correctly
- [x] Save/Unsave functionality works
- [x] Confirmation dialog displays properly
- [x] Saved quotes persist across reloads
- [x] No console errors

## Files Modified/Added
- angular.json, shared.service.ts, quote-card.component.ts
- saved-quotes.component.ts/html
- NEW: theme.scss, confirm-dialog.component.ts